### PR TITLE
add shebang for ci/run-docker.sh

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Small script to run tests for a target (or all targets) inside all the
 # respective docker images.
 


### PR DESCRIPTION
stumbled upon this when debian-packaging, there's a lint for script
files without shebang (#!/some/interpreter) on top