### PR TITLE
AVX-512 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ env_logger = "0.6"
 [features]
 default = []
 dft = []
+static = []

--- a/build.rs
+++ b/build.rs
@@ -85,13 +85,25 @@ fn main() {
             bindings = bindings.blacklist_type(v).opaque_type(v);
         }
 
+        if features.contains("avx512f") {
+            let vs = [
+                // AVX-512
+                "__m512", "__m512i", "__m512d",
+            ];
+
+            for v in &vs {
+                bindings = bindings.blacklist_type(v).opaque_type(v);
+            }
+        }
+
         let x86_features = {
-            let mut features = std::collections::HashMap::<String, String>::default();
-            features.insert("sse2".to_string(), "__SSE2__".to_string());
-            features.insert("avx".to_string(), "__AVX__".to_string());
-            // FIXME: AVX-512
-            // features.insert("avx512f".to_string(), "__AVX512F__".to_string());
-            features
+            let mut x86_features = std::collections::HashMap::<String, String>::default();
+            x86_features.insert("sse2".to_string(), "__SSE2__".to_string());
+            x86_features.insert("avx".to_string(), "__AVX__".to_string());
+            if features.contains("avx512f") {
+                x86_features.insert("avx512f".to_string(), "__AVX512F__".to_string());
+            }
+            x86_features
         };
         for f in &features {
             if let Some(def) = x86_features.get(f) {

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ types) and the SLEEF APIs that use it are not included in these bindings _yet_
   SIMD-vectorized and parallelized subroutines for discrete Fourier transform
   (DFT) with an API similar to FFTW.
 
+* **static** (default: disabled) Link sleef statically
+
 ### Platform support
 
 This wrapper supports the following platforms, but CI is not properly set up for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ cfg_if! {
             __m128, __m128i, __m128d,
             // AVX:
             __m256, __m256i, __m256d,
-            // FIXME: AVX-512:
-            //__m512, __m512i, __m512d,
         };
+        #[cfg(target_feature = "avx512f")]
+        pub use self::x86::{ __m512, __m512i, __m512d };
     } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
         pub use core::arch::aarch64::{
             int8x8_t, uint8x8_t, poly8x8_t, int16x4_t, uint16x4_t,


### PR DESCRIPTION
Enables bindings for AVX-512 SLEEF functions. Based on @greatest-ape static linking branch.  
Didn't write any tests, needed this for a project and figured I would add a PR in case someone wanted to write them and merge.